### PR TITLE
Repositories: create, update, delete complete

### DIFF
--- a/NWEEI/NWEEI/Repositories/Articles/ArticleRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/ArticleRepo.cs
@@ -69,5 +69,11 @@ namespace NWEEI.Repositories
 
         #endregion
 
+        public void UpdateArticle(Article article)
+        {
+            context.Articles.Update(article);
+            context.SaveChanges();
+        }
+
     }
 }

--- a/NWEEI/NWEEI/Repositories/Articles/ArticleRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/ArticleRepo.cs
@@ -86,5 +86,12 @@ namespace NWEEI.Repositories
             context.SaveChanges();
         }
 
+        // delete an article
+        public void DeleteArticle(Article article)
+        {
+            Article existingArticle = context.Articles.Find(article.ArticleID);
+            context.Articles.Remove(existingArticle);
+            context.SaveChanges();
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Articles/ArticleRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/ArticleRepo.cs
@@ -16,9 +16,6 @@ namespace NWEEI.Repositories
             context = c;
         }
 
-
-        #region retrieval methods
-
         public IQueryable<Article> Articles
         {
             get
@@ -29,6 +26,16 @@ namespace NWEEI.Repositories
             }
         }
 
+        // add a new article
+        public void AddArticle(Article article)
+        {
+            context.Articles.Add(article);
+            context.SaveChanges();
+        }
+
+        #region retrieval methods
+
+        // get a list of all articles
         public List<Article> GetAllArticles()
         {
             List<Article> articles = context.Articles.OrderByDescending(a => a.DateCreated)
@@ -39,6 +46,7 @@ namespace NWEEI.Repositories
             return articles;
         }
 
+        // get a list of articles by category
         public List<Article> GetArticlesByCategoryID(int categoryID)
         {
             List<Article> articles = context.Articles.OrderByDescending(a => a.DateCreated)
@@ -51,11 +59,13 @@ namespace NWEEI.Repositories
         }
 
         // TODO: build out search functionality
+        // get all articles that include a word or phrase
         public List<Article> GetArticlesBySearchQuery(string query)
         {
             throw new NotImplementedException();
         }
 
+        // get a specific article by its id
         public Article GetArticleByID(int id)
         {
             Article article = context.Articles
@@ -69,6 +79,7 @@ namespace NWEEI.Repositories
 
         #endregion
 
+        // update an article
         public void UpdateArticle(Article article)
         {
             context.Articles.Update(article);

--- a/NWEEI/NWEEI/Repositories/Articles/ArticleTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/ArticleTestRepo.cs
@@ -44,5 +44,23 @@ namespace NWEEI.Repositories
             Article article = articles.Find(a => a.ArticleID == id);
             return article;
         }
+
+        // TODO: write test update method
+        public void UpdateArticle(Article article)
+        {
+            // retrieve article from list
+            Article existingArticle = articles.Find(a => a.ArticleID == a.ArticleID);
+
+            // update its properties
+            existingArticle.Title = article.Title;
+            existingArticle.Body = article.Body;
+            existingArticle.DateCreated = article.DateCreated;
+            existingArticle.Author = article.Author;
+            existingArticle.Category = article.Category;
+            existingArticle.PublishDate = article.PublishDate;
+            existingArticle.IsPublished = article.IsPublished;
+            existingArticle.Featured = article.Featured;
+            existingArticle.Views = article.Views;
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Articles/ArticleTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/ArticleTestRepo.cs
@@ -17,6 +17,26 @@ namespace NWEEI.Repositories
             }
         }
 
+        // add a new article
+        public void AddArticle(Article article)
+        {
+            // attempt to retrieve existing article
+            Article existingArticle = articles.Find(a => a.Title == article.Title && a.Body == article.Body);
+
+            // add article to list if it doesn't already exist
+            if (existingArticle == null)
+            {
+                // simulate auto-incremented primary key and add article to list
+                article.ArticleID = articles.Count;
+                articles.Add(article);
+            }
+            else
+            {
+                throw new Exception("Article already exists");
+            }
+        }
+
+        // get a list of all articles
         public List<Article> GetAllArticles()
         {
             articles = Articles.ToList();
@@ -24,6 +44,7 @@ namespace NWEEI.Repositories
             return articles;
         }
 
+        // get a list of articles by category
         public List<Article> GetArticlesByCategoryID(int categoryID)
         {
             List<Article> articlesByCategory = articles
@@ -39,13 +60,14 @@ namespace NWEEI.Repositories
             throw new NotImplementedException();
         }
 
+        // get a specific article by its id
         public Article GetArticleByID(int id)
         {
             Article article = articles.Find(a => a.ArticleID == id);
             return article;
         }
 
-        // TODO: write test update method
+        // update an article
         public void UpdateArticle(Article article)
         {
             // retrieve article from list

--- a/NWEEI/NWEEI/Repositories/Articles/ArticleTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/ArticleTestRepo.cs
@@ -84,5 +84,12 @@ namespace NWEEI.Repositories
             existingArticle.Featured = article.Featured;
             existingArticle.Views = article.Views;
         }
+
+        // delete an article
+        public void DeleteArticle(Article article)
+        {
+            Article existingArticle = articles.Find(a => a.ArticleID == article.ArticleID);
+            articles.Remove(existingArticle);
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Articles/IArticleRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/IArticleRepo.cs
@@ -7,12 +7,14 @@ namespace NWEEI.Repositories
 {
     public interface IArticleRepo
     {
-        // retrieval methods
+        // retrieval
         IQueryable<Article> Articles { get; }
         List<Article> GetAllArticles();
         List<Article> GetArticlesByCategoryID(int categoryID);
         List<Article> GetArticlesBySearchQuery(string query);
         Article GetArticleByID(int id);
 
+        // update
+        void UpdateArticle(Article article);
     }
 }

--- a/NWEEI/NWEEI/Repositories/Articles/IArticleRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/IArticleRepo.cs
@@ -20,5 +20,8 @@ namespace NWEEI.Repositories
 
         // update
         void UpdateArticle(Article article);
+
+        // delete
+        void DeleteArticle(Article article);
     }
 }

--- a/NWEEI/NWEEI/Repositories/Articles/IArticleRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/IArticleRepo.cs
@@ -7,8 +7,12 @@ namespace NWEEI.Repositories
 {
     public interface IArticleRepo
     {
-        // retrieval
         IQueryable<Article> Articles { get; }
+
+        // create
+        void AddArticle(Article article);
+
+        // retrieve
         List<Article> GetAllArticles();
         List<Article> GetArticlesByCategoryID(int categoryID);
         List<Article> GetArticlesBySearchQuery(string query);

--- a/NWEEI/NWEEI/Repositories/Categories/CategoryRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Categories/CategoryRepo.cs
@@ -15,6 +15,12 @@ namespace NWEEI.Repositories
             context = c;
         }
 
+        // create a new category
+        public void AddCategory(Category category)
+        {
+            context.Categories.Add(category);
+            context.SaveChanges();
+        }
 
         #region retrieval methods
 
@@ -26,6 +32,7 @@ namespace NWEEI.Repositories
             }
         }
 
+        // get a list of all categories
         public List<Category> GetAllCategories()
         {
             List<Category> categories = context.Categories.ToList();
@@ -33,6 +40,7 @@ namespace NWEEI.Repositories
             return categories;
         }
 
+        // get a specific category by its id
         public Category GetCategoryByID(int id)
         {
             Category category = context.Categories

--- a/NWEEI/NWEEI/Repositories/Categories/CategoryRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Categories/CategoryRepo.cs
@@ -52,9 +52,18 @@ namespace NWEEI.Repositories
 
         #endregion
 
+        // update a category
         public void UpdateCategory(Category category)
         {
             context.Categories.Update(category);
+            context.SaveChanges();
+        }
+
+        // delete a category
+        public void DeleteCategory(Category category)
+        {
+            Category existingCategory = context.Categories.Find(category.CategoryID);
+            context.Categories.Remove(existingCategory);
             context.SaveChanges();
         }
     }

--- a/NWEEI/NWEEI/Repositories/Categories/CategoryRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Categories/CategoryRepo.cs
@@ -43,5 +43,11 @@ namespace NWEEI.Repositories
         }
 
         #endregion
+
+        public void UpdateCategory(Category category)
+        {
+            context.Categories.Update(category);
+            context.SaveChanges();
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Categories/CategoryTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Categories/CategoryTestRepo.cs
@@ -60,5 +60,12 @@ namespace NWEEI.Repositories
             // update its properties
             existingCategory.Name = category.Name;
         }
+
+        // delete a category
+        public void DeleteCategory(Category category)
+        {
+            Category existingCategory = categories.Find(c => c.CategoryID == category.CategoryID);
+            categories.Remove(existingCategory);
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Categories/CategoryTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Categories/CategoryTestRepo.cs
@@ -29,5 +29,15 @@ namespace NWEEI.Repositories
             Category category = categories.Find(c => c.CategoryID == id);
             return category;
         }
+
+        // TODO: write test update method
+        public void UpdateCategory(Category category)
+        {
+            // retrieve category from list
+            Category existingCategory = categories.Find(c => c.CategoryID == c.CategoryID);
+
+            // update its properties
+            existingCategory.Name = category.Name;
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Categories/CategoryTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Categories/CategoryTestRepo.cs
@@ -17,6 +17,26 @@ namespace NWEEI.Repositories
             }
         }
 
+        // create a new category
+        public void AddCategory(Category category)
+        {
+            // attempt to retrieve existing category
+            Category existingCategory = categories.Find(c => c.Name == category.Name);
+
+            // add category to list if it doesn't already exist
+            if (existingCategory == null)
+            {
+                // simulate auto-incremented primary key and add category to list
+                category.CategoryID = categories.Count;
+                categories.Add(category);
+            }
+            else
+            {
+                throw new Exception("Category already exists");
+            }
+        }
+
+        // get a list of all categories
         public List<Category> GetAllCategories()
         {
             categories = Categories.ToList();
@@ -24,13 +44,14 @@ namespace NWEEI.Repositories
             return categories;
         }
 
+        // get a specific category by its id
         public Category GetCategoryByID(int id)
         {
             Category category = categories.Find(c => c.CategoryID == id);
             return category;
         }
 
-        // TODO: write test update method
+        // update a category
         public void UpdateCategory(Category category)
         {
             // retrieve category from list

--- a/NWEEI/NWEEI/Repositories/Categories/ICategoryRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Categories/ICategoryRepo.cs
@@ -19,5 +19,8 @@ namespace NWEEI.Repositories
 
         // update
         void UpdateCategory(Category category);
+
+        // delete
+        void DeleteCategory(Category category);
     }
 }

--- a/NWEEI/NWEEI/Repositories/Categories/ICategoryRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Categories/ICategoryRepo.cs
@@ -8,8 +8,12 @@ namespace NWEEI.Repositories
 {
     public interface ICategoryRepo
     {
-        // retrieval methods
         IQueryable<Category> Categories { get; }
+
+        // create
+        void AddCategory(Category category);
+
+        // retrieve
         List<Category> GetAllCategories();
         Category GetCategoryByID(int id);
 

--- a/NWEEI/NWEEI/Repositories/Categories/ICategoryRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Categories/ICategoryRepo.cs
@@ -12,5 +12,8 @@ namespace NWEEI.Repositories
         IQueryable<Category> Categories { get; }
         List<Category> GetAllCategories();
         Category GetCategoryByID(int id);
+
+        // update
+        void UpdateCategory(Category category);
     }
 }

--- a/NWEEI/NWEEI/Repositories/FAQs/FAQRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/FAQRepo.cs
@@ -63,5 +63,11 @@ namespace NWEEI.Repositories
         }
 
         #endregion
+
+        public void UpdateFAQ(FAQ faq)
+        {
+            context.FAQs.Update(faq);
+            context.SaveChanges();
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/FAQs/FAQRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/FAQRepo.cs
@@ -16,9 +16,6 @@ namespace NWEEI.Repositories
             context = c;
         }
 
-
-        #region retrieval methods
-
         public IQueryable<FAQ> FAQs
         {
             get
@@ -27,6 +24,16 @@ namespace NWEEI.Repositories
             }
         }
 
+        // add a new FAQ
+        public void AddFAQ(FAQ faq)
+        {
+            context.FAQs.Add(faq);
+            context.SaveChanges();
+        }
+
+        #region retrieval methods
+
+        // get a list of all FAQs
         public List<FAQ> GetAllFAQs()
         {
             List<FAQ> faqs = context.FAQs
@@ -36,6 +43,7 @@ namespace NWEEI.Repositories
             return faqs;
         }
 
+        // get a list of FAQs by category
         public List<FAQ> GetFAQsByCategoryID(int categoryID)
         {
             List<FAQ> faqs = context.FAQs
@@ -52,6 +60,7 @@ namespace NWEEI.Repositories
             throw new NotImplementedException();
         }
 
+        // get a specific FAQ by its id
         public FAQ GetFAQByID(int id)
         {
             FAQ faq = context.FAQs
@@ -64,6 +73,7 @@ namespace NWEEI.Repositories
 
         #endregion
 
+        // update a FAQ
         public void UpdateFAQ(FAQ faq)
         {
             context.FAQs.Update(faq);

--- a/NWEEI/NWEEI/Repositories/FAQs/FAQRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/FAQRepo.cs
@@ -79,5 +79,13 @@ namespace NWEEI.Repositories
             context.FAQs.Update(faq);
             context.SaveChanges();
         }
+
+        // delete a FAQ
+        public void DeleteFAQ(FAQ faq)
+        {
+            FAQ existingFAQ = context.FAQs.Find(faq.FAQID);
+            context.FAQs.Remove(existingFAQ);
+            context.SaveChanges();
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/FAQs/FAQTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/FAQTestRepo.cs
@@ -18,6 +18,26 @@ namespace NWEEI.Repositories
             }
         }
 
+        // add a new FAQ
+        public void AddFAQ(FAQ faq)
+        {
+            // attempt to retrieve existing FAQ
+            FAQ existingFAQ = faqs.Find(f => f.Question == faq.Question);
+
+            // add FAQ to list if it doesn't already exist
+            if (existingFAQ == null)
+            {
+                // simulate auto-incremented primary key and add FAQ to list
+                faq.FAQID = faqs.Count;
+                faqs.Add(faq);
+            }
+            else
+            {
+                throw new Exception("FAQ already exists");
+            }
+        }
+
+        // get a list of all FAQs
         public List<FAQ> GetAllFAQs()
         {
             faqs = FAQs.ToList();
@@ -25,6 +45,7 @@ namespace NWEEI.Repositories
             return faqs;
         }
 
+        // get a list of FAQs by category
         public List<FAQ> GetFAQsByCategoryID(int categoryID)
         {
             List<FAQ> faqsByCategory = faqs
@@ -40,12 +61,14 @@ namespace NWEEI.Repositories
             throw new NotImplementedException();
         }
 
+        // get a specific FAQ by its id
         public FAQ GetFAQByID(int id)
         {
             FAQ faq = faqs.Find(f => f.FAQID == id);
             return faq;
         }
 
+        // update a FAQ
         public void UpdateFAQ(FAQ faq)
         {
             // retrieve faq from list

--- a/NWEEI/NWEEI/Repositories/FAQs/FAQTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/FAQTestRepo.cs
@@ -81,5 +81,12 @@ namespace NWEEI.Repositories
             existingFAQ.IsPublished = faq.IsPublished;
             existingFAQ.Featured = faq.Featured;
         }
+
+        // delete a FAQ
+        public void DeleteFAQ(FAQ faq)
+        {
+            FAQ existingFAQ = faqs.Find(f => f.FAQID == faq.FAQID);
+            faqs.Remove(existingFAQ);
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/FAQs/FAQTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/FAQTestRepo.cs
@@ -45,5 +45,18 @@ namespace NWEEI.Repositories
             FAQ faq = faqs.Find(f => f.FAQID == id);
             return faq;
         }
+
+        public void UpdateFAQ(FAQ faq)
+        {
+            // retrieve faq from list
+            FAQ existingFAQ = faqs.Find(f => f.FAQID == faq.FAQID);
+
+            // update its properties
+            existingFAQ.Question = faq.Question;
+            existingFAQ.Answer = faq.Answer;
+            existingFAQ.Category = faq.Category;
+            existingFAQ.IsPublished = faq.IsPublished;
+            existingFAQ.Featured = faq.Featured;
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/FAQs/IFAQRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/IFAQRepo.cs
@@ -21,5 +21,8 @@ namespace NWEEI.Repositories
 
         // update
         void UpdateFAQ(FAQ faq);
+
+        // delete
+        void DeleteFAQ(FAQ faq);
     }
 }

--- a/NWEEI/NWEEI/Repositories/FAQs/IFAQRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/IFAQRepo.cs
@@ -14,5 +14,8 @@ namespace NWEEI.Repositories
         List<FAQ> GetFAQsByCategoryID(int categoryID);
         List<FAQ> GetFAQsBySearchQuery(string query);
         FAQ GetFAQByID(int id);
+
+        // update
+        void UpdateFAQ(FAQ faq);
     }
 }

--- a/NWEEI/NWEEI/Repositories/FAQs/IFAQRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/IFAQRepo.cs
@@ -8,8 +8,12 @@ namespace NWEEI.Repositories
 {
     public interface IFAQRepo
     {
-        // retrieval methods
         IQueryable<FAQ> FAQs { get; }
+
+        // create
+        void AddFAQ(FAQ faq);
+
+        // retrieve
         List<FAQ> GetAllFAQs();
         List<FAQ> GetFAQsByCategoryID(int categoryID);
         List<FAQ> GetFAQsBySearchQuery(string query);

--- a/NWEEI/NWEEI/Repositories/Organizations/IOrganizationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Organizations/IOrganizationRepo.cs
@@ -7,8 +7,12 @@ namespace NWEEI.Repositories
 {
     public interface IOrganizationRepo
     {
-        // retrieval methods
         IQueryable<Organization> Organizations { get; }
+
+        // create
+        void AddOrganization(Organization organization);
+
+        // retrieve
         List<Organization> GetAllOrganizations();
         List<Organization> GetOrganizationsByTagID(int tagID);
         Organization GetOrganizationByID(int id);

--- a/NWEEI/NWEEI/Repositories/Organizations/IOrganizationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Organizations/IOrganizationRepo.cs
@@ -19,5 +19,8 @@ namespace NWEEI.Repositories
 
         // update
         void UpdateOrganization(Organization organization);
+
+        // delete
+        void DeleteOrganization(Organization organization);
     }
 }

--- a/NWEEI/NWEEI/Repositories/Organizations/IOrganizationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Organizations/IOrganizationRepo.cs
@@ -12,5 +12,8 @@ namespace NWEEI.Repositories
         List<Organization> GetAllOrganizations();
         List<Organization> GetOrganizationsByTagID(int tagID);
         Organization GetOrganizationByID(int id);
+
+        // update
+        void UpdateOrganization(Organization organization);
     }
 }

--- a/NWEEI/NWEEI/Repositories/Organizations/OrganizationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Organizations/OrganizationRepo.cs
@@ -71,5 +71,13 @@ namespace NWEEI.Repositories
             context.Organizations.Update(organization);
             context.SaveChanges();
         }
+
+        // delete an organization
+        public void DeleteOrganization(Organization organization)
+        {
+            Organization existingOrg = context.Organizations.Find(organization.OrganizationID);
+            context.Organizations.Remove(existingOrg);
+            context.SaveChanges();
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Organizations/OrganizationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Organizations/OrganizationRepo.cs
@@ -58,5 +58,11 @@ namespace NWEEI.Repositories
         }
 
         #endregion
+
+        public void UpdateOrganization(Organization organization)
+        {
+            context.Organizations.Update(organization);
+            context.SaveChanges();
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Organizations/OrganizationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Organizations/OrganizationRepo.cs
@@ -16,9 +16,6 @@ namespace NWEEI.Repositories
             context = c;
         }
 
-
-        #region retrieval methods
-
         public IQueryable<Organization> Organizations
         {
             get
@@ -27,7 +24,17 @@ namespace NWEEI.Repositories
                     .Include(org => org.Tags);
             }
         }
-        
+
+        // add a new organization
+        public void AddOrganization(Organization organization)
+        {
+            context.Add(organization);
+            context.SaveChanges();
+        }
+
+        #region retrieval methods
+
+        // get a list of all organizations
         public List<Organization> GetAllOrganizations()
         {
             List<Organization> organizations = context.Organizations
@@ -37,8 +44,7 @@ namespace NWEEI.Repositories
 
             return organizations;
         }
-
-        
+                
         // TODO: decide how to handle this - include tag methods within org repo
         // for retrieval by tagID?
         public List<Organization> GetOrganizationsByTagID(int tagID)
@@ -46,7 +52,7 @@ namespace NWEEI.Repositories
             throw new NotImplementedException();
         }
         
-
+        // get a specific organization by its id
         public Organization GetOrganizationByID(int id)
         {
             Organization organization = context.Organizations
@@ -59,6 +65,7 @@ namespace NWEEI.Repositories
 
         #endregion
 
+        // update an organization
         public void UpdateOrganization(Organization organization)
         {
             context.Organizations.Update(organization);

--- a/NWEEI/NWEEI/Repositories/Organizations/OrganizationTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Organizations/OrganizationTestRepo.cs
@@ -36,5 +36,24 @@ namespace NWEEI.Repositories
             Organization organization = organizations.Find(org => org.OrganizationID == id);
             return organization;
         }
+
+        public void UpdateOrganization(Organization organization)
+        {
+            // retrieve organization from list
+            Organization existingOrg = organizations.Find(o => o.OrganizationID == organization.OrganizationID);
+
+            // update its properties
+            existingOrg.Name = organization.Name;
+            existingOrg.Description = organization.Description;
+            existingOrg.ImageURL = organization.ImageURL;
+            existingOrg.WebsiteURL = organization.WebsiteURL;
+
+            // clear list of tags and set to new org's tags
+            existingOrg.Tags.Clear();
+            foreach (Tag t in organization.Tags)
+            {
+                existingOrg.Tags.Add(t);
+            }
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Organizations/OrganizationTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Organizations/OrganizationTestRepo.cs
@@ -77,5 +77,12 @@ namespace NWEEI.Repositories
                 existingOrg.Tags.Add(t);
             }
         }
+
+        // delete an organization
+        public void DeleteOrganization(Organization organization)
+        {
+            Organization existingOrg = organizations.Find(o => o.OrganizationID == organization.OrganizationID);
+            organizations.Remove(existingOrg);
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Organizations/OrganizationTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Organizations/OrganizationTestRepo.cs
@@ -17,6 +17,26 @@ namespace NWEEI.Repositories
             }
         }
 
+        // add a new organization
+        public void AddOrganization(Organization organization)
+        {
+            // attempt to retrieve existing organization
+            Organization existingOrg = organizations.Find(o => o.Name == organization.Name);
+
+            // add organization to list if it doesn't already exist
+            if (existingOrg == null)
+            {
+                // simulate auto-incremented primary key and add organization to list
+                organization.OrganizationID = organizations.Count;
+                organizations.Add(organization);
+            }
+            else
+            {
+                throw new Exception("Organization already exists");
+            }
+        }
+
+        // get a list of all organizations
         public List<Organization> GetAllOrganizations()
         {
             organizations = Organizations.ToList();
@@ -31,12 +51,14 @@ namespace NWEEI.Repositories
             throw new NotImplementedException();
         }
 
+        // get a specific organization by its id
         public Organization GetOrganizationByID(int id)
         {
             Organization organization = organizations.Find(org => org.OrganizationID == id);
             return organization;
         }
 
+        // update an organization
         public void UpdateOrganization(Organization organization)
         {
             // retrieve organization from list

--- a/NWEEI/NWEEI/Repositories/Registrations/IRegistrationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Registrations/IRegistrationRepo.cs
@@ -11,5 +11,8 @@ namespace NWEEI.Repositories
         IQueryable<Registration> Registrations { get; }
         List<Registration> GetAllRegistrations();
         Registration GetRegistrationByID(int id);
+
+        // update
+        void UpdateRegistration(Registration registration);
     }
 }

--- a/NWEEI/NWEEI/Repositories/Registrations/IRegistrationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Registrations/IRegistrationRepo.cs
@@ -18,5 +18,8 @@ namespace NWEEI.Repositories
 
         // update
         void UpdateRegistration(Registration registration);
+
+        // delete
+        void DeleteRegistration(Registration registration);
     }
 }

--- a/NWEEI/NWEEI/Repositories/Registrations/IRegistrationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Registrations/IRegistrationRepo.cs
@@ -7,8 +7,12 @@ namespace NWEEI.Repositories
 {
     public interface IRegistrationRepo
     {
-        // retrieval methods
         IQueryable<Registration> Registrations { get; }
+
+        // create
+        void AddRegistration(Registration registration);
+
+        // retrieve
         List<Registration> GetAllRegistrations();
         Registration GetRegistrationByID(int id);
 

--- a/NWEEI/NWEEI/Repositories/Registrations/RegistrationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Registrations/RegistrationRepo.cs
@@ -61,5 +61,14 @@ namespace NWEEI.Repositories
             context.Registrations.Update(registration);
             context.SaveChanges();
         }
+
+        // delete a registration
+        public void DeleteRegistration(Registration registration)
+        {
+            Registration existingRegistration = context.Registrations
+                .Find(registration.RegistrationID);
+            context.Registrations.Remove(existingRegistration);
+            context.SaveChanges();
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Registrations/RegistrationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Registrations/RegistrationRepo.cs
@@ -16,8 +16,6 @@ namespace NWEEI.Repositories
             context = c;
         }
 
-        #region retrieval methods
-
         public IQueryable<Registration> Registrations
         {
             get
@@ -26,6 +24,16 @@ namespace NWEEI.Repositories
             }
         }
 
+        // add a new registration
+        public void AddRegistration(Registration registration)
+        {
+            context.Registrations.Add(registration);
+            context.SaveChanges();
+        }
+
+        #region retrieval methods
+
+        // get a list of all registrations
         public List<Registration> GetAllRegistrations()
         {
             List<Registration> registrations = context.Registrations
@@ -35,6 +43,7 @@ namespace NWEEI.Repositories
             return registrations;
         }
 
+        // get a specific registration by its id
         public Registration GetRegistrationByID(int id)
         {
             Registration registration = context.Registrations
@@ -46,6 +55,7 @@ namespace NWEEI.Repositories
 
         #endregion
 
+        // update a registration
         public void UpdateRegistration(Registration registration)
         {
             context.Registrations.Update(registration);

--- a/NWEEI/NWEEI/Repositories/Registrations/RegistrationRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Registrations/RegistrationRepo.cs
@@ -45,5 +45,11 @@ namespace NWEEI.Repositories
         }
 
         #endregion
+
+        public void UpdateRegistration(Registration registration)
+        {
+            context.Registrations.Update(registration);
+            context.SaveChanges();
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Registrations/RegistrationTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Registrations/RegistrationTestRepo.cs
@@ -17,6 +17,27 @@ namespace NWEEI.Repositories
             }
         }
 
+        // add a new registration
+        public void AddRegistration(Registration registration)
+        {
+            // attempt to retrieve existing registration
+            Registration existingRegistration = registrations
+                .Find(r => r.FirstName == registration.FirstName && r.LastName == registration.LastName);
+
+            // add registration to list if it doesn't already exist
+            if (existingRegistration == null)
+            {
+                // simulate auto-incremented primary key and add registration to list
+                registration.RegistrationID = registrations.Count;
+                registrations.Add(registration);
+            }
+            else
+            {
+                throw new Exception("Registration already exists");
+            }
+        }
+
+        // get a list of all registrations
         public List<Registration> GetAllRegistrations()
         {
             registrations = Registrations.ToList();
@@ -24,13 +45,14 @@ namespace NWEEI.Repositories
             return registrations;
         }
 
+        // get a specific registration by its id
         public Registration GetRegistrationByID(int id)
         {
             Registration registration = registrations.Find(r => r.RegistrationID == id);
             return registration;
         }
 
-        // TODO: write test update method
+        // update a registration
         public void UpdateRegistration(Registration registration)
         {
             // retrieve registration from list

--- a/NWEEI/NWEEI/Repositories/Registrations/RegistrationTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Registrations/RegistrationTestRepo.cs
@@ -29,5 +29,32 @@ namespace NWEEI.Repositories
             Registration registration = registrations.Find(r => r.RegistrationID == id);
             return registration;
         }
+
+        // TODO: write test update method
+        public void UpdateRegistration(Registration registration)
+        {
+            // retrieve registration from list
+            Registration existingReg = registrations.Find(r => r.RegistrationID == registration.RegistrationID);
+
+            // update its properties
+            existingReg.TrainingProgram = registration.TrainingProgram;
+            existingReg.FirstName = registration.FirstName;
+            existingReg.LastName = registration.LastName;
+            existingReg.Email = registration.Email;
+            existingReg.DateOfBirth = registration.DateOfBirth;
+            existingReg.Title = registration.Title;
+            existingReg.Organization = registration.Organization;
+            existingReg.Address1 = registration.Address1;
+            existingReg.Address2 = registration.Address2;
+            existingReg.City = registration.City;
+            existingReg.State = registration.State;
+            existingReg.ZipCode = registration.ZipCode;
+            existingReg.Country = registration.Country;
+            existingReg.Phone = registration.Phone;
+            existingReg.Fax = registration.Fax;
+            existingReg.Referral = registration.Referral;
+            existingReg.SpecialInstructions = registration.SpecialInstructions;
+            existingReg.PaymentType = registration.PaymentType;
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Registrations/RegistrationTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Registrations/RegistrationTestRepo.cs
@@ -78,5 +78,12 @@ namespace NWEEI.Repositories
             existingReg.SpecialInstructions = registration.SpecialInstructions;
             existingReg.PaymentType = registration.PaymentType;
         }
+
+        // delete a registration
+        public void DeleteRegistration(Registration registration)
+        {
+            Registration existingRegistration = registrations.Find(r => r.RegistrationID == registration.RegistrationID);
+            registrations.Remove(existingRegistration);
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Tags/ITagRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Tags/ITagRepo.cs
@@ -7,8 +7,12 @@ namespace NWEEI.Repositories
 {
     public interface ITagRepo
     {
-        // retrieval methods
         IQueryable<Tag> Tags { get; }
+
+        // create
+        void AddTag(Tag tag);
+
+        // retrieve
         List<Tag> GetAllTags();
         Tag GetTagByID(int id);
 

--- a/NWEEI/NWEEI/Repositories/Tags/ITagRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Tags/ITagRepo.cs
@@ -18,5 +18,8 @@ namespace NWEEI.Repositories
 
         // update
         void UpdateTag(Tag tag);
+
+        // delete
+        void DeleteTag(Tag tag);
     }
 }

--- a/NWEEI/NWEEI/Repositories/Tags/ITagRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Tags/ITagRepo.cs
@@ -11,5 +11,8 @@ namespace NWEEI.Repositories
         IQueryable<Tag> Tags { get; }
         List<Tag> GetAllTags();
         Tag GetTagByID(int id);
+
+        // update
+        void UpdateTag(Tag tag);
     }
 }

--- a/NWEEI/NWEEI/Repositories/Tags/TagRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Tags/TagRepo.cs
@@ -59,5 +59,13 @@ namespace NWEEI.Repositories
             context.Tags.Update(tag);
             context.SaveChanges();
         }
+
+        // delete a tag
+        public void DeleteTag(Tag tag)
+        {
+            Tag existingTag = context.Tags.Find(tag.TagID);
+            context.Tags.Remove(existingTag);
+            context.SaveChanges();
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Tags/TagRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Tags/TagRepo.cs
@@ -44,5 +44,11 @@ namespace NWEEI.Repositories
         }
 
         #endregion
+
+        public void UpdateTag(Tag tag)
+        {
+            context.Tags.Update(tag);
+            context.SaveChanges();
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Tags/TagRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Tags/TagRepo.cs
@@ -16,9 +16,6 @@ namespace NWEEI.Repositories
             context = c;
         }
 
-
-        #region retrieval methods
-
         public IQueryable<Tag> Tags
         {
             get
@@ -27,6 +24,16 @@ namespace NWEEI.Repositories
             }
         }
 
+        // add a new tag
+        public void AddTag(Tag tag)
+        {
+            context.Tags.Add(tag);
+            context.SaveChanges();
+        }
+
+        #region retrieval methods
+
+        // get a list of all tags
         public List<Tag> GetAllTags()
         {
             List<Tag> tags = context.Tags.ToList();
@@ -34,6 +41,7 @@ namespace NWEEI.Repositories
             return tags;
         }
 
+        // get a specific tag by its id
         public Tag GetTagByID(int id)
         {
             Tag tag = context.Tags
@@ -45,6 +53,7 @@ namespace NWEEI.Repositories
 
         #endregion
 
+        // update a tag
         public void UpdateTag(Tag tag)
         {
             context.Tags.Update(tag);

--- a/NWEEI/NWEEI/Repositories/Tags/TagTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Tags/TagTestRepo.cs
@@ -17,6 +17,26 @@ namespace NWEEI.Repositories
             }
         }
 
+        // add a new tag
+        public void AddTag(Tag tag)
+        {
+            // attempt to retrieve existing tag
+            Tag existingTag = tags.Find(t => t.Name == tag.Name);
+
+            // add tag to list if it doesn't already exist
+            if (existingTag == null)
+            {
+                // simulate auto-incremented primary key and add article to list
+                tag.TagID = tags.Count;
+                tags.Add(tag);
+            }
+            else
+            {
+                throw new Exception("Tag already exists");
+            }
+        }
+
+        // get a list of all tags
         public List<Tag> GetAllTags()
         {
             tags = Tags.ToList();
@@ -24,12 +44,14 @@ namespace NWEEI.Repositories
             return tags;
         }
 
+        // get a specific tag by its id
         public Tag GetTagByID(int id)
         {
             Tag tag = tags.Find(t => t.TagID == id);
             return tag;
         }
 
+        // update a tag
         public void UpdateTag(Tag tag)
         {
             // retrieve tag from list

--- a/NWEEI/NWEEI/Repositories/Tags/TagTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Tags/TagTestRepo.cs
@@ -60,5 +60,12 @@ namespace NWEEI.Repositories
             // update its properties
             existingTag.Name = tag.Name;
         }
+
+        // delete a tag
+        public void DeleteTag(Tag tag)
+        {
+            Tag existingTag = tags.Find(t => t.TagID == tag.TagID);
+            tags.Remove(existingTag);
+        }
     }
 }

--- a/NWEEI/NWEEI/Repositories/Tags/TagTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Tags/TagTestRepo.cs
@@ -29,5 +29,14 @@ namespace NWEEI.Repositories
             Tag tag = tags.Find(t => t.TagID == id);
             return tag;
         }
+
+        public void UpdateTag(Tag tag)
+        {
+            // retrieve tag from list
+            Tag existingTag = tags.Find(t => t.TagID == tag.TagID);
+
+            // update its properties
+            existingTag.Name = tag.Name;
+        }
     }
 }


### PR DESCRIPTION
Finished building out interfaces/repositories for Articles, Categories, FAQs, Organizations, Tags, and Registrations with create, update, and delete methods.  All repos are now complete with methods for all CRUD operations. The only method remaining to finish is the method that retrieves articles based on a search query.