### PR TITLE
Search functionality

### DIFF
--- a/NWEEI/NWEEI/Controllers/ArticleController.cs
+++ b/NWEEI/NWEEI/Controllers/ArticleController.cs
@@ -45,7 +45,15 @@ namespace NWEEI.Controllers
         public async Task<IActionResult> Category(int categoryID)
         {
             ViewBag.Current = "Resources";
-            return View(repo.GetArticlesByCategoryID(categoryID));
+
+            // if current user is admin return all articles
+            if (User.IsInRole("Admin"))
+            {
+                return View(repo.GetArticlesByCategoryID(categoryID));
+            }
+
+            // otherwise only return published articles
+            return View(repo.GetPublishedArticlesByCategoryID(categoryID));
         }
 
         // GET: Article/Details/5
@@ -252,6 +260,8 @@ namespace NWEEI.Controllers
             return repo.Articles.Any(e => e.ArticleID == id);
         }
 
+        #region RTE methods
+
         // for rich text editor
         string GetHtmlFileCode()
         {
@@ -358,6 +368,7 @@ namespace NWEEI.Controllers
             }
         }
 
+#endregion
 
     }
 }

--- a/NWEEI/NWEEI/Controllers/FAQController.cs
+++ b/NWEEI/NWEEI/Controllers/FAQController.cs
@@ -41,7 +41,9 @@ namespace NWEEI.Controllers
         public async Task<IActionResult> ByCategory(int categoryID)
         {
             ViewBag.Current = "Resources";
-            return View(repo.GetFAQsByCategoryID(categoryID));
+
+            // only return published FAQs
+            return View(repo.GetPublishedFAQsByCategoryID(categoryID));
         }
 
         // GET: FAQ/Details/5

--- a/NWEEI/NWEEI/Controllers/Navigation/ResourcesController.cs
+++ b/NWEEI/NWEEI/Controllers/Navigation/ResourcesController.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using NWEEI.Models;
+using NWEEI.Repositories;
+using NWEEI.ViewModels;
 
 // For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -10,12 +13,60 @@ namespace NWEEI.Controllers.Navigation
 {
     public class ResourcesController : Controller
     {
-        // GET: /<controller>/
-        public IActionResult Index()
+        IResourceRepo repo;
+
+        public ResourcesController(IResourceRepo r)
+        {
+            repo = r;
+        }
+
+        // GET: /Resources/Search
+        // search articles, FAQs, organizations
+        public async Task<IActionResult> Index()
         {
             ViewBag.Current = "Resources";
-            return View();
+
+            // initialize new searchVM
+            SearchViewModel viewModel = new SearchViewModel
+            {
+                SearchQuery = "",
+                HasResults = false,
+                Articles = new List<Article>(),
+                FAQs = new List<FAQ>(),
+                Organizations = new List<Organization>()
+            };
+
+            return View(viewModel);
         }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        // search articles, FAQs, organizations
+        public async Task<IActionResult> Index(SearchViewModel viewModel)
+        {
+            ViewBag.Current = "Resources";
+
+            if (ModelState.IsValid)
+            {
+                // get lists of articles, FAQs, and organizations
+                // that contain the search query
+                viewModel.Articles = repo.GetArticlesBySearchQuery(viewModel.SearchQuery);
+                viewModel.FAQs = repo.GetFAQsBySearchQuery(viewModel.SearchQuery);
+                //viewModel.Organizations = repo.GetOrgsBySearchQuery(viewModel.SearchQuery);
+
+                // if results are found, set HasResults to true
+                // TODO: update to include orgs once built out
+                if (viewModel.Articles.Count > 0 || viewModel.FAQs.Count > 0)
+                {
+                    viewModel.HasResults = true;
+                }
+
+                return View(viewModel);
+            }
+
+            return NotFound();
+        }
+
         public IActionResult CareerMap()
         {
             ViewBag.Current = "Resources";

--- a/NWEEI/NWEEI/NWEEI.csproj
+++ b/NWEEI/NWEEI/NWEEI.csproj
@@ -23,6 +23,7 @@
     <None Remove="Repositories\Registration\" />
     <None Remove="Repositories\Tag\" />
     <None Remove="Repositories\FAQs\" />
+    <None Remove="Repositories\Resources\" />
   </ItemGroup>
   <ItemGroup>
     <None Update="app.db" CopyToOutputDirectory="PreserveNewest" ExcludeFromSingleFile="true" />
@@ -56,5 +57,6 @@
     <Folder Include="Repositories\Registrations\" />
     <Folder Include="Repositories\Tags\" />
     <Folder Include="Repositories\FAQs\" />
+    <Folder Include="Repositories\Resources\" />
   </ItemGroup>
 </Project>

--- a/NWEEI/NWEEI/Repositories/Articles/ArticleRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/ArticleRepo.cs
@@ -38,7 +38,21 @@ namespace NWEEI.Repositories
         // get a list of all articles
         public List<Article> GetAllArticles()
         {
-            List<Article> articles = context.Articles.OrderByDescending(a => a.DateCreated)
+            List<Article> articles = context.Articles
+                .OrderBy(a => a.DateCreated)
+                .Include(a => a.Author)
+                .Include(a => a.Category)
+                .ToList();
+
+            return articles;
+        }
+
+        // get a list of all published articles
+        public List<Article> GetPublishedArticles()
+        {
+            List<Article> articles = context.Articles
+                .Where(a => a.IsPublished == true)
+                .OrderBy(a => a.DateCreated)
                 .Include(a => a.Author)
                 .Include(a => a.Category)
                 .ToList();
@@ -49,7 +63,8 @@ namespace NWEEI.Repositories
         // get a list of articles by category
         public List<Article> GetArticlesByCategoryID(int categoryID)
         {
-            List<Article> articles = context.Articles.OrderByDescending(a => a.DateCreated)
+            List<Article> articles = context.Articles
+                .OrderBy(a => a.DateCreated)
                 .Include(a => a.Author)
                 .Include(a => a.Category)
                 .Where(a => a.Category.CategoryID == categoryID)
@@ -58,11 +73,18 @@ namespace NWEEI.Repositories
             return articles;
         }
 
-        // TODO: build out search functionality
-        // get all articles that include a word or phrase
-        public List<Article> GetArticlesBySearchQuery(string query)
+        // get a list of published articles by category
+        public List<Article> GetPublishedArticlesByCategoryID(int categoryID)
         {
-            throw new NotImplementedException();
+            List<Article> articles = context.Articles
+                .Where(a => a.IsPublished == true)
+                .OrderBy(a => a.DateCreated)
+                .Include(a => a.Author)
+                .Include(a => a.Category)
+                .Where(a => a.Category.CategoryID == categoryID)
+                .ToList();
+
+            return articles;
         }
 
         // get a specific article by its id

--- a/NWEEI/NWEEI/Repositories/Articles/ArticleTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/ArticleTestRepo.cs
@@ -45,6 +45,17 @@ namespace NWEEI.Repositories
             return articles;
         }
 
+        // get a list of all published articles
+        public List<Article> GetPublishedArticles()
+        {
+            List<Article> articles = Articles
+                .Where(a => a.IsPublished == true)
+                .OrderBy(a => a.DateCreated)
+                .ToList();
+
+            return articles;
+        }
+
         // get a list of articles by category
         public List<Article> GetArticlesByCategoryID(int categoryID)
         {
@@ -55,10 +66,16 @@ namespace NWEEI.Repositories
             return articlesByCategory;
         }
 
-        // TODO: build out search functionality
-        public List<Article> GetArticlesBySearchQuery(string query)
+        // get a list of articles by category
+        public List<Article> GetPublishedArticlesByCategoryID(int categoryID)
         {
-            throw new NotImplementedException();
+            List<Article> articles = Articles
+                .Where(a => a.IsPublished == true)
+                .OrderBy(a => a.DateCreated)
+                .Where(a => a.Category.CategoryID == categoryID)
+                .ToList();
+
+            return articles;
         }
 
         // get a specific article by its id

--- a/NWEEI/NWEEI/Repositories/Articles/IArticleRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Articles/IArticleRepo.cs
@@ -14,8 +14,9 @@ namespace NWEEI.Repositories
 
         // retrieve
         List<Article> GetAllArticles();
+        List<Article> GetPublishedArticles();
         List<Article> GetArticlesByCategoryID(int categoryID);
-        List<Article> GetArticlesBySearchQuery(string query);
+        List<Article> GetPublishedArticlesByCategoryID(int categoryID);
         Article GetArticleByID(int id);
         List<Category> GetAllCategories();
 

--- a/NWEEI/NWEEI/Repositories/FAQs/FAQRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/FAQRepo.cs
@@ -43,12 +43,35 @@ namespace NWEEI.Repositories
             return faqs;
         }
 
+        // get a list of published FAQs
+        public List<FAQ> GetPublishedFAQs()
+        {
+            List<FAQ> faqs = context.FAQs
+                .Where(faq => faq.IsPublished == true)
+                .Include(faq => faq.Category)
+                .ToList();
+
+            return faqs;
+        }
+
         // get a list of FAQs by category
         public List<FAQ> GetFAQsByCategoryID(int categoryID)
         {
             List<FAQ> faqs = context.FAQs
                 .Include(faq => faq.Category)
                 .Where(faq => faq.Category.CategoryID == categoryID)
+                .ToList();
+
+            return faqs;
+        }
+
+        // get a list of published  FAQs by category
+        public List<FAQ> GetPublishedFAQsByCategoryID(int categoryID)
+        {
+            List<FAQ> faqs = context.FAQs
+                .Include(faq => faq.Category)
+                .Where(faq => faq.Category.CategoryID == categoryID)
+                .Where(faq => faq.IsPublished == true)
                 .ToList();
 
             return faqs;
@@ -63,12 +86,6 @@ namespace NWEEI.Repositories
                 .ToList();
 
             return faqCategories;
-        }
-
-        // TODO: build out search functionality
-        public List<FAQ> GetFAQsBySearchQuery(string query)
-        {
-            throw new NotImplementedException();
         }
 
         // get a specific FAQ by its id

--- a/NWEEI/NWEEI/Repositories/FAQs/FAQTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/FAQTestRepo.cs
@@ -46,6 +46,17 @@ namespace NWEEI.Repositories
             return faqs;
         }
 
+        // get a list of published FAQs
+        public List<FAQ> GetPublishedFAQs()
+        {
+            List<FAQ> faqs = FAQs
+                .Where(faq => faq.IsPublished == true)
+                .Include(faq => faq.Category)
+                .ToList();
+
+            return faqs;
+        }
+
         // get a list of FAQs by category
         public List<FAQ> GetFAQsByCategoryID(int categoryID)
         {
@@ -56,15 +67,21 @@ namespace NWEEI.Repositories
             return faqsByCategory;
         }
 
+        // get a list of published FAQs by category
+        public List<FAQ> GetPublishedFAQsByCategoryID(int categoryID)
+        {
+            List<FAQ> faqs = FAQs
+                .Include(faq => faq.Category)
+                .Where(faq => faq.Category.CategoryID == categoryID)
+                .Where(faq => faq.IsPublished == true)
+                .ToList();
+
+            return faqs;
+        }
+
         // TODO: write GetFAQCategories method and unit test
         // get a list of categories that have FAQs
         public List<Category> GetFAQCategories()
-        {
-            throw new NotImplementedException();
-        }
-
-        // TODO: build out search functionality
-        public List<FAQ> GetFAQsBySearchQuery(string query)
         {
             throw new NotImplementedException();
         }

--- a/NWEEI/NWEEI/Repositories/FAQs/IFAQRepo.cs
+++ b/NWEEI/NWEEI/Repositories/FAQs/IFAQRepo.cs
@@ -15,9 +15,10 @@ namespace NWEEI.Repositories
 
         // retrieve
         List<FAQ> GetAllFAQs();
+        List<FAQ> GetPublishedFAQs();
         List<FAQ> GetFAQsByCategoryID(int categoryID);
+        List<FAQ> GetPublishedFAQsByCategoryID(int categoryID);
         List<Category> GetFAQCategories();
-        List<FAQ> GetFAQsBySearchQuery(string query);
         FAQ GetFAQByID(int id);
         List<Category> GetAllCategories();
 

--- a/NWEEI/NWEEI/Repositories/Resources/IResourceRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Resources/IResourceRepo.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NWEEI.Models;
+
+namespace NWEEI.Repositories
+{
+    public interface IResourceRepo
+    {
+        IQueryable<Article> Articles { get; }
+        IQueryable<FAQ> FAQs { get; }
+        IQueryable<Organization> Organizations { get; }
+
+        // retrieval with search query
+        List<Article> GetArticlesBySearchQuery(string query);
+        List<FAQ> GetFAQsBySearchQuery(string query);
+        List<Organization> GetOrgsBySearchQuery(string query);
+    }
+}

--- a/NWEEI/NWEEI/Repositories/Resources/ResourceRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Resources/ResourceRepo.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using NWEEI.Data;
+using NWEEI.Models;
+
+namespace NWEEI.Repositories
+{
+    public class ResourceRepo : IResourceRepo
+    {
+        private NWEEIContext context;
+
+        public ResourceRepo(NWEEIContext c)
+        {
+            context = c;
+        }
+
+        #region articles
+
+        public IQueryable<Article> Articles
+        {
+            get
+            {
+                return context.Articles.Include(a => a.Category);
+            }
+        }
+
+        // get published articles that contain the search query
+        // in either the title or body
+        public List<Article> GetArticlesBySearchQuery(string query)
+        {
+            List<Article> articles = context.Articles
+                .Where(a => a.Title.Contains(query) || a.Body.Contains(query))
+                .Where(a => a.IsPublished == true)
+                .OrderBy(a => a.DateCreated)
+                .Include(a => a.Author)
+                .Include(a => a.Category)
+                .ToList();
+
+            return articles;
+        }
+
+        #endregion
+
+
+        #region FAQs
+
+        public IQueryable<FAQ> FAQs
+        {
+            get
+            {
+                return context.FAQs.Include(f => f.Category);
+            }
+        }
+
+        // get published FAQs that contain the search query
+        // in either the question or answer
+        public List<FAQ> GetFAQsBySearchQuery(string query)
+        {
+            List<FAQ> faqs = context.FAQs
+                .Where(f => f.Question.Contains(query) || f.Answer.Contains(query))
+                .Where(f => f.IsPublished == true)
+                .Include(f => f.Category)
+                .ToList();
+
+            return faqs;
+        }
+
+
+        #endregion
+
+
+        #region organizations
+
+        public IQueryable<Organization> Organizations
+        {
+            get
+            {
+                return context.Organizations
+                    .Include(o => o.Tags)
+                    .Include(o => o.TagKeys);
+            }
+        }
+
+        // get organization that contain the search query
+        // in either the name or description
+        public List<Organization> GetOrgsBySearchQuery(string query)
+        {
+            List<Organization> organizations = context.Organizations
+                .Where(o => o.Name.Contains(query) || o.Description.Contains(query))
+                //.Include(o => o.Tags)
+                .Include(o => o.TagKeys)
+                .ToList();
+
+            return organizations;
+        }
+
+        #endregion
+    }
+}

--- a/NWEEI/NWEEI/Repositories/Resources/ResourceTestRepo.cs
+++ b/NWEEI/NWEEI/Repositories/Resources/ResourceTestRepo.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using NWEEI.Models;
+
+namespace NWEEI.Repositories
+{
+    public class ResourceTestRepo : IResourceRepo
+    {
+        private List<Article> articles = new List<Article>();
+        private List<FAQ> faqs = new List<FAQ>();
+        private List<Organization> organizations = new List<Organization>();
+
+        #region articles
+
+        public IQueryable<Article> Articles
+        {
+            get
+            {
+                return articles.AsQueryable<Article>();
+            }
+        }
+
+        // get published articles that contain the search query
+        // in either the title or body
+        public List<Article> GetArticlesBySearchQuery(string query)
+        {
+            List<Article> matchingArticles = articles
+                .Where(a => a.Title.Contains(query) || a.Body.Contains(query))
+                .Where(a => a.IsPublished == true)
+                .ToList();
+
+            return matchingArticles;
+        }
+
+        #endregion
+
+
+        #region FAQs
+
+        public IQueryable<FAQ> FAQs
+        {
+            get
+            {
+                return faqs.AsQueryable<FAQ>();
+            }
+        }
+
+        // get published FAQs that contain the search query
+        // in either the question or answer
+        public List<FAQ> GetFAQsBySearchQuery(string query)
+        {
+            List<FAQ> matchingFAQs = faqs
+                .Where(f => f.Question.Contains(query) || f.Answer.Contains(query))
+                .Where(f => f.IsPublished == true)
+                .ToList();
+
+            return matchingFAQs;
+        }
+
+
+        #endregion
+
+
+        #region organizations
+
+        public IQueryable<Organization> Organizations
+        {
+            get
+            {
+                return organizations.AsQueryable<Organization>();
+            }
+        }
+
+        // get organization that contain the search query
+        // in either the name or description
+        public List<Organization> GetOrgsBySearchQuery(string query)
+        {
+            List<Organization> matchingOrgs = organizations
+                .Where(o => o.Name.Contains(query) || o.Description.Contains(query))
+                .ToList();
+
+            return matchingOrgs;
+        }
+
+        #endregion
+    }
+}

--- a/NWEEI/NWEEI/Startup.cs
+++ b/NWEEI/NWEEI/Startup.cs
@@ -1,19 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.UI;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.EntityFrameworkCore;
 using NWEEI.Data;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NWEEI.Models;
-using Microsoft.Data.Sqlite;
 using MySql.Data.MySqlClient;
 using NWEEI.Repositories;
 
@@ -53,6 +46,7 @@ namespace NWEEI
             services.AddTransient<IPaymentOptionRepo, PaymentOptionRepo>();
             services.AddTransient<ITrainingProgramRepo, TrainingProgramRepo>();
             services.AddTransient<ITagRepo, TagRepo>();
+            services.AddTransient<IResourceRepo, ResourceRepo>();
 
             services.AddRazorPages();
             services.AddControllersWithViews().AddRazorRuntimeCompilation();

--- a/NWEEI/NWEEI/ViewModels/SearchViewModel.cs
+++ b/NWEEI/NWEEI/ViewModels/SearchViewModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using NWEEI.Models;
+
+namespace NWEEI.ViewModels
+{
+    public class SearchViewModel
+    {
+        public string SearchQuery { get; set; }
+        public bool HasResults { get; set; }
+        public List<Article> Articles { get; set; }
+        public List<FAQ> FAQs { get; set; }
+        public List<Organization> Organizations { get; set; }
+    }
+}

--- a/NWEEI/NWEEI/Views/Category/Index.cshtml
+++ b/NWEEI/NWEEI/Views/Category/Index.cshtml
@@ -52,7 +52,7 @@ else
     <div class="container tiles">
         @foreach (var item in Model)
         {
-            @if (item.Articles.Count > 0)
+            @if (item.Articles.Where(a => a.IsPublished == true).ToList().Count > 0)
             {
                 <a class="tile-link" asp-controller="Article" asp-action="Category" asp-route-categoryID="@item.CategoryID">
                     <div class="tile-container">

--- a/NWEEI/NWEEI/Views/FAQ/Index.cshtml
+++ b/NWEEI/NWEEI/Views/FAQ/Index.cshtml
@@ -15,7 +15,7 @@
     @* loop through each category and display FAQs *@
     @foreach (var item in Model)
     {
-        @if (item.FAQs.Count > 0)
+        @if (item.FAQs.Where(f => f.IsPublished == true).ToList().Count > 0)
         {
             <a class="tile-link" asp-controller="FAQ" asp-action="ByCategory" asp-route-categoryID="@item.CategoryID">
                 <div class="tile-container">

--- a/NWEEI/NWEEI/Views/Resources/Index.cshtml
+++ b/NWEEI/NWEEI/Views/Resources/Index.cshtml
@@ -1,5 +1,133 @@
-﻿@*
-    For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
-*@
+﻿@model NWEEI.ViewModels.SearchViewModel
+@using System.Text.RegularExpressions;
+
 @{
+    ViewData["Title"] = "Resources";
 }
+
+<!-- search -->
+<div class="dark-block search-container">
+    <div class="container">
+        <div class="content-section" style="line-height:1.5em;">
+
+            <h4 class="text-center">Search NWEEI</h4>
+
+            <form asp-action="Index">
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div class="form-group search-bar">
+                    <!-- search input and icon -->
+                    <div class="search-bar-content">
+                        <!-- search input -->
+                        <input asp-for="SearchQuery" class="form-control search-bar" />
+
+                        <!-- icon -->
+                        <span class="search-submit">
+                            <button type="submit" style="background: none; color: inherit; border: none; padding: 0; font: inherit; cursor: pointer; outline: inherit; position: absolute;">
+                                <i type="submit" class="fa fa-search"></i>
+                            </button>
+                        </span>
+                    </div>
+                </div>
+            </form>
+
+
+        </div>
+    </div>
+</div>
+
+<!-- results -->
+<div class="container">
+    @if (Model.HasResults)
+    {
+        <div>
+            <h6>
+                Your search for "@Model.SearchQuery" returned
+                <a href="#article-results">@Model.Articles.Count articles</a>
+                and <a href="#faq-results">@Model.FAQs.Count FAQs</a>.
+            </h6>
+            <div>
+            </div>
+        </div>
+    }
+
+    <!-- articles -->
+    @if (Model.Articles.Count > 0)
+    {
+        <div id="article-results" class="search-results-container">
+            <h4>Articles</h4>
+
+            @foreach (var article in Model.Articles)
+            {
+                <div class="search-result">
+                    <div class="search-result-heading">
+                        <a asp-controller="Article" asp-action="Details" asp-route-id="@article.ArticleID">
+                            @article.Title
+                        </a>
+                    </div>
+                    <div class="search-preview">
+                        <span>
+                            @if (article.Body.Length < 250)
+                            {
+                                @Regex.Replace(article.Body, "<.*?>", string.Empty)
+                            }
+                            else
+                            {
+                                @Regex.Replace(article.Body.Substring(0, 250), "<.*?>", string.Empty)
+                            }
+                            ...
+                        </span>
+                    </div>
+                </div>
+            }
+
+        </div>
+    }
+
+    <!-- FAQs -->
+    @if (Model.FAQs.Count > 0)
+    {
+        <div id="faq-results" class="search-results-container">
+            <h4>FAQs</h4>
+
+            @foreach (var faq in Model.FAQs)
+            {
+                <div class="search-result">
+                    <div class="search-result-heading">
+                        <a asp-controller="FAQ" asp-action="Details" asp-route-id="@faq.FAQID">
+                            @faq.Question
+                        </a>
+                    </div>
+                    <div class="search-preview">
+                        <span>
+                            @if (faq.Answer.Length < 250)
+                            {
+                                @Regex.Replace(faq.Answer, "<.*?>", string.Empty);
+                            }
+                            else
+                            {
+                                @Regex.Replace(faq.Answer.Substring(0, 250), "<.*?>", string.Empty);
+                            }
+                            ...
+                        </span>
+                    </div>
+                </div>
+            }
+
+        </div>
+    }
+
+    @* TODO: uncomment when organizations are finished
+        <!-- Organizations -->
+        @if (Model.Organizations.Count > 0)
+        {
+        <div id="org-results" class="search-results-container">
+            <h5>Organizations</h5>
+            @foreach (var org in Model.Organizations)
+            {
+                <div>@org.Name</div>
+            }
+        </div>
+        }
+    *@
+
+</div>

--- a/NWEEI/NWEEI/wwwroot/css/site.css
+++ b/NWEEI/NWEEI/wwwroot/css/site.css
@@ -569,3 +569,54 @@ body {
 
 
 
+/* -------------------------------------------------- */
+
+
+/* SEARCH */
+
+.search-container {
+    text-align: center;
+    position: relative;
+    top: -2.19em;
+}
+
+.search-bar {
+    border-radius: 20px;
+    width: 70%;
+    margin: auto;
+    padding: 15px;
+    display: inline !important;
+    position: relative;
+}
+
+.search-bar-content {
+    width: 100%;
+}
+
+.search-submit {
+    position: relative;
+    right: 2%;
+    top: 11px;
+}
+
+.search-submit i {
+    position: absolute;
+    right: 3%;
+}
+
+.search-results-container {
+    margin: 4% 0%;
+}
+
+.search-result {
+    padding: 1% 0%;
+}
+
+.search-result-heading {
+    font-size: 0.9em;
+}
+
+.search-preview > * {
+    color: grey !important;
+    font-size: 0.8em !important;
+}


### PR DESCRIPTION
Implemented search functionality that pulls articles and FAQs when the article title or body or FAQ question or answer contains the search query. Search input and output have both been styled in the Resources/Index view. 

There's a regex that strips some html, not all, from the article body previews in the search results so text size and styling would be uniform and not include html tags. It's probably worth circling back to at some point to work out a more comprehensive regex.

Also, updated article retrieval methods to support publish/unpublish functionality.